### PR TITLE
added account, lstorage and SingCache flexibility

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -12,6 +12,10 @@ nextflowVersion = '!>=20.07.1'
 // Set default workflow parameters
 // See https://www.nextflow.io/docs/latest/config.html#scope-params 
 params {
+    	pbs_account = "$PROJECT"
+	storage_account = ''
+    	whoami = ''
+	singularityCacheDir = ''
 	help	= false
 	outdir = "results"
 	input	= false
@@ -64,6 +68,17 @@ singularity {
 	enabled = true
 	autoMounts = true
 	autoCleanUp = true
+	
+	cacheDir = params.singularityCacheDir
+		? params.singularityCacheDir
+        	: "/scratch/${params.pbs_account}/${params.whoami}/.nextflow/singularity"
+		
+		
+	libraryDir = params.singularityCacheDir
+		? params.singularityCacheDir
+        	: "/scratch/${params.pbs_account}/${params.whoami}/.nextflow/singularity"	
+	
+	temp = "/scratch/${params.pbs_account}/${params.whoami}/.nextflow/singularity/temp"	
 }
 
 // Set default resources for each process 
@@ -72,7 +87,24 @@ process {
 	module = 'singularity'
 	cache = 'lenient'
 	project = "${params.gadi_account}"
-	storage = "scratch/${params.gadi_account}+gdata/${params.gadi_account}"
+
+	
+	// Enable provision of multiple storage paths for -l directive
+	storage = ''
+    	storage = 'scratch/${params.pbs_account}+gdata/${params.pbs_account}'
+    	ext.storageAccountString = { accountString ->
+        	accountString.tokenize(',').collect { acct ->
+            	"scratch/${acct}+gdata/${acct}"
+        	}.join('+')
+    	}
+    
+    	if (params.storage_account) {
+        	storage = "scratch/${params.pbs_account}+gdata/${params.pbs_account}+${ext.storageAccountString(params.storage_account)}"
+    	} 
+	else {
+        	storage = "scratch/${params.pbs_account}+gdata/${params.pbs_account}"
+    	} 	
+	
 
 	withName: 'check_input' {
 		executor = 'local'
@@ -88,8 +120,6 @@ process {
 		cpus = 1
 		time = '10h'
 		memory = 4.Gb
-		project = 'iz89'
-		storage = 'scratch/er01'
 	}	
 
 	withName: 'pb_fq2bam' {
@@ -99,8 +129,6 @@ process {
 		gpus = 2
 		time = '1h'
 		memory = 190.Gb
-		project = 'iz89'
-		storage = 'scratch/er01'
 	}
 
 	withName: 'pb_collectmetrics' {
@@ -110,8 +138,6 @@ process {
 		gpus = 2
 		time = '1h'
 		memory = 190.Gb
-		project = 'iz89'
-		storage = 'scratch/er01'
 	}
 
 	withName: 'pb_deepvariant' {
@@ -121,8 +147,6 @@ process {
 		gpus = 2
 		time = '1h'
 		memory = 190.Gb
-		project = 'iz89'
-		storage = 'scratch/er01'
 	}
 
 	withName: 'glnexus_joint_call' {


### PR DESCRIPTION
Added new parameters to nextflow.config: storage_account and singularityCacheDir
this enables the user to have a different PBS account used for accounting vs scratch and gdata
Singularity cachedir parameter is used for singularity cache dir and library cache dir, if not provided by user, looks in default location (/scratch/${params.pbs_account}/${params.whoami}/.nextflow/singularity)
