### PR TITLE
Change glnexus container

### DIFF
--- a/config/gadi.config
+++ b/config/gadi.config
@@ -71,7 +71,7 @@ process {
 	withName: 'multiqc' {
 		queue = 'normalbw'
 		cpus = 1
-		memory = 4.Gb
+		memory = 10.Gb
 	}
 
 	withName: 'pb_fq2bam' {
@@ -99,7 +99,10 @@ process {
 	}
 
 	withName: 'glnexus_joint_call' {
-		executor = 'local'
+                queue = 'normal'
+                cpus = 48
+                time = '10h'
+                memory = 190.Gb
 	}
 	
 	withName: 'download_vep' {

--- a/config/gadi.config
+++ b/config/gadi.config
@@ -99,10 +99,10 @@ process {
 	}
 
 	withName: 'glnexus_joint_call' {
-                queue = 'normal'
-                cpus = 48
-                time = '10h'
-                memory = 190.Gb
+    queue = 'normal'
+    cpus = 48
+    time = '10h'
+    memory = 190.Gb
 	}
 	
 	withName: 'download_vep' {

--- a/modules/glnexus_joint.nf
+++ b/modules/glnexus_joint.nf
@@ -1,7 +1,7 @@
 process glnexus_joint_call {
     tag "JOINT GENOTYPING: ${params.cohort_name}" 
     publishDir "${params.outdir}/variants", mode: 'symlink'
-    container "quay.io/biocontainers/glnexus:1.4.1--h5c1b0a6_3"
+    container "ghcr.io/dnanexus-rnd/glnexus:v1.4.1"
 
     input:
     path(gvcf_list) 


### PR DESCRIPTION
The container does not contain jemalloc, which is recommended by GLnexus developes in order to improve performance at high thread counts.  The updated container does include jemalloc (version 5.2.1-0-gea6b3e973b477b8061e0076bb257dbd7f3faa756)