### PR TITLE
Allow multiple versions of parabricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Description 
 
-Parabricks-Genomics-nf is a GPU-enabled pipeline for alignment and germline short variant calling for short read sequencing data. The pipeline utilises [NVIDIA's Clara Parabricks](https://docs.nvidia.com/clara/parabricks/4.2.0/index.html) toolkit to dramatically speed up the execution of best practice bioinformatics tools. Currently, this pipeline is **configured specifically for [NCI's Gadi HPC](https://nci.org.au/our-systems/hpc-systems)**. 
+Parabricks-Genomics-nf is a GPU-enabled pipeline for alignment and germline short variant calling for short read sequencing data. The pipeline utilises [NVIDIA's Clara Parabricks](https://docs.nvidia.com/clara/parabricks/) toolkit to dramatically speed up the execution of best practice bioinformatics tools. Currently, this pipeline is **configured specifically for [NCI's Gadi HPC](https://nci.org.au/our-systems/hpc-systems)**. 
 
 NVIDIA's Clara Parabricks can deliver a significant speed improvement over traditional CPU-based methods, and is designed to be used only with NVIDIA GPUs. This pipeline is suitable for population screening projects as it executes Parabrick's implementations of BWA mem for short read alignment and Google's DeepVariant for short variant calling. Additionally, it uses standard CPU implementations of data quality evaluation tools [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/) and [MultiQC](https://multiqc.info/) and [DNAnexus' GLnexus](https://academic.oup.com/bioinformatics/article/36/24/5582/6064144) for scalable gVCF merging and joint variant calling. Optionally, [Variant Effect Predictor (VEP)](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0974-4) can be run for variant annotation. 
 
@@ -143,21 +143,38 @@ For available species caches, please see the [VEP cache download site](https://f
 The most basic run command for this pipeline is:
 
 ```bash
-nextflow run main.nf --input sample.tsv --ref /path/to/ref --gadi_account <account-code> -profile gadi
+nextflow run main.nf --input sample.csv --ref /path/to/ref --gadi_account <account-code> -profile gadi
 ```
 
-This will run the following processes: 
+This will run the following processes:
 
-* Check validity of provided inputs 
+* Check validity of provided inputs
 * [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/) for summary of raw reads
 * [BWA index](https://bio-bwa.sourceforge.net/bwa.shtml) if bwa indexes for your provided reference fasta are not detected
-* [Parabricks' fq2bam](https://docs.nvidia.com/clara/parabricks/4.2.0/documentation/tooldocs/man_fq2bam.html#man-fq2bam) for performing read alignment and generating bam files for individuals
-* [Parabricks' deepvariant](https://docs.nvidia.com/clara/parabricks/4.2.0/documentation/tooldocs/man_deepvariant.html#man-deepvariant) for performing SNV/indel genotyping for individuals 
-* [Parabricks' bammetrics](https://docs.nvidia.com/clara/parabricks/4.2.0/documentation/tooldocs/man_bammetrics.html#man-bammetrics) for generating alignment metrics 
-* [Glnexus](https://github.com/dnanexus-rnd/GLnexus) for joint genotyping of all individuals and creation of a cohort-level BCF file 
+* [Parabricks' fq2bam](https://docs.nvidia.com/clara/parabricks/latest/documentation/tooldocs/man_fq2bam.html) for performing read alignment and generating bam files for individuals
+* [Parabricks' deepvariant](https://docs.nvidia.com/clara/parabricks/latest/documentation/tooldocs/man_deepvariant.html) for performing SNV/indel genotyping for individuals
+* [Parabricks' bammetrics](https://docs.nvidia.com/clara/parabricks/latest/documentation/tooldocs/man_bammetrics.html) for generating alignment metrics
+* [Glnexus](https://github.com/dnanexus-rnd/GLnexus) for joint genotyping of all individuals and creation of a cohort-level BCF file
 * [BCFtools convert](https://samtools.github.io/bcftools/bcftools.html) to convert the cohort BCF to a VCF
 * [BCFtools stats](https://samtools.github.io/bcftools/bcftools.html) for summary statistics of the cohort VCF
 * [MultiQC](https://multiqc.info/) for generating a summary html report of all processes
+
+#### Selecting a Parabricks version and GPU queue
+
+By default, this pipeline loads Parabricks 4.6.0 and submits GPU jobs to the `dgxa100` queue (NVIDIA A100 GPUs). If the `dgxa100` queue is in high demand, you can instead run on the `gpuvolta` queue (NVIDIA V100 GPUs) using Parabricks 4.3.2:
+
+| `--parabricks_version` | Queue      | GPU        | CPUs/node | Memory/node |
+|------------------------|------------|------------|-----------|-------------|
+| `4.6.0` (default)      | `dgxa100`  | A100       | 128       | ~2 TB       |
+| `4.3.2`                | `gpuvolta` | V100       | 48        | 382 GB      |
+
+To run on `gpuvolta`:
+
+```bash
+nextflow run main.nf --input sample.csv --ref /path/to/ref --gadi_account <account-code> -profile gadi --parabricks_version 4.3.2
+```
+
+The pipeline automatically adjusts the queue, CPU, and memory allocations based on the version you specify. The Parabricks version used in a run is recorded in the startup log and in each GPU task's `.command.log`, and is correctly reflected in the MultiQC report.
 
 Additionally, you can run variant annotation using variant effect predictor by adding some additional flags `--download_vep_cache`, `--vep_species`, and `--vep_assembly` as specified in [section 2.2](#22-variant-effect-predictor-cache) above: 
 
@@ -221,17 +238,17 @@ To run this pipeline on infrastructures other than NCI Gadi, you will need to cr
 
 To run this pipeline you must have Nextflow and Singularity installed. All other tools are run as containers using Singularity.
 
-|Tool         | Version  |
-|-------------|:---------|
-|Nextflow     |>=20.07.1 |
-|Singularity  |          |
-|Parabricks   |4.6.0     |
-|BCFtools     |1.17      |
-|BWA          |0.7.17    |
-|FastQC       |0.12.1    |
-|Glnexus      |0.2.7     |
-|MultiQC      |1.21      |
-|VEP          |110.1     |
+|Tool         | Version          |
+|-------------|:-----------------|
+|Nextflow     |>=20.07.1         |
+|Singularity  |                  |
+|Parabricks   |4.6.0 or 4.3.2    |
+|BCFtools     |1.17              |
+|BWA          |0.7.17            |
+|FastQC       |0.12.1            |
+|Glnexus      |0.2.7             |
+|MultiQC      |1.21              |
+|VEP          |110.1             |
 
 
 

--- a/config/gadi.config
+++ b/config/gadi.config
@@ -22,18 +22,16 @@ singularity {
 process {
     withLabel: parabricks {
         stageInMode = "copy"
-        module = "parabricks/4.6.0"
+        module = { params.parabricks_version == '4.3.2' ? 'parabricks/4.3.2' : 'parabricks/4.6.0' }
     }
 }
 
 // Submit up to 300 concurrent jobs (Gadi exec max)
 // pollInterval and queueStatInterval of every 30 seconds
-// submitRateLimit of 20 per minute
 executor {
     queueSize = 300
     pollInterval = '30 sec'
     queueStatInterval = '30 sec'
-    submitRateLimit = '20 min'
 }
 
 // Set default resources for each process 

--- a/config/modules.config
+++ b/config/modules.config
@@ -40,27 +40,28 @@ process {
     }
 
     withName: pb_fq2bam {
-        queue = 'dgxa100'
-        cpus = { task.gpus * 16 }
+        // gpuvolta: 4x V100, 48 CPUs, 382 GB per node; dgxa100: 8x A100, 128 CPUs, ~2 TB per node
+        queue = { params.parabricks_version == '4.3.2' ? 'gpuvolta' : 'dgxa100' }
         gpus = 4
+        cpus = { params.parabricks_version == '4.3.2' ? task.gpus * 12 : task.gpus * 16 }
         time = '4h'
         memory = 380.Gb
     }
 
     withName: pb_deepvariant {
-        queue = 'dgxa100'
-        cpus = { task.gpus * 16 }
+        queue = { params.parabricks_version == '4.3.2' ? 'gpuvolta' : 'dgxa100' }
         gpus = 4
+        cpus = { params.parabricks_version == '4.3.2' ? task.gpus * 12 : task.gpus * 16 }
         time = '4h'
         memory = 380.Gb
     }
 
     withName: pb_collectmetrics {
-        queue = 'dgxa100'
-        cpus = { task.gpus * 16 }
+        queue = { params.parabricks_version == '4.3.2' ? 'gpuvolta' : 'dgxa100' }
         gpus = 1
+        cpus = { params.parabricks_version == '4.3.2' ? task.gpus * 12 : task.gpus * 16 }
         time = '1h'
-        memory = 190.Gb
+        memory = { params.parabricks_version == '4.3.2' ? 95.Gb : 190.Gb }
     }
 
     withName: glnexus_joint_call {

--- a/main.nf
+++ b/main.nf
@@ -27,15 +27,22 @@ Genomics001: Parabricks-Genomics-nf
 \033[35mCite this pipeline @ INSERT DOI\033[0m
 
 \033[1m\033[33m=======================================================================================
-Workflow run parameters 
+Workflow run parameters
 =======================================================================================\033[0m
-\033[32minput_samples\033[0m : ${params.input}
-\033[32mcohort_name\033[0m   : ${params.cohort_name}
-\033[32mresults_dir\033[0m   : ${params.outdir}
-\033[32mreference\033[0m     : ${params.ref}
-\033[32mvep_species\033[0m   : ${params.vep_species}
-\033[32mvep_assembly\033[0m  : ${params.vep_assembly}
-\033[32mworkDir\033[0m       : ${workflow.workDir}
+\033[32minput_samples\033[0m      : ${params.input}
+\033[32mcohort_name\033[0m        : ${params.cohort_name}
+\033[32mresults_dir\033[0m        : ${params.outdir}
+\033[32mreference\033[0m          : ${params.ref}
+\033[32mvep_species\033[0m        : ${params.vep_species}
+\033[32mvep_assembly\033[0m       : ${params.vep_assembly}
+\033[32mworkDir\033[0m            : ${workflow.workDir}
+
+\033[1m\033[33m=======================================================================================
+Parabricks GPU configuration
+=======================================================================================\033[0m
+\033[32mparabricks_version\033[0m : ${params.parabricks_version}
+\033[32mmodule\033[0m             : parabricks/${params.parabricks_version}
+\033[32mgpu_queue\033[0m          : ${params.parabricks_version == '4.3.2' ? 'gpuvolta (V100)' : 'dgxa100 (A100)'}
 \033[1m\033[33m=======================================================================================\033[0m
 
 """
@@ -64,11 +71,13 @@ def helpMessage() {
 
   \033[34m--storage_account\033[0m     Specify NCI Gadi storage paths. For example, "scratch/ab01+gdata/xy89"
 
+  \033[34m--parabricks_version\033[0m  Parabricks version to load: '4.6.0' (dgxa100 queue) or '4.3.2' (gpuvolta queue). Default: 4.6.0.
+
   \033[34m--download_vep_cache\033[0m  Download the required cache (default: false).
 
-  \033[34m--vep_species\033[0m         Specify which species cache to download from VEP (default: false).        
+  \033[34m--vep_species\033[0m         Specify which species cache to download from VEP (default: false).
 
-  \033[34m--vep_assembly\033[0m        Specify which assembly cache to download from VEP (default: false).   
+  \033[34m--vep_assembly\033[0m        Specify which assembly cache to download from VEP (default: false).
 
 """.stripIndent()
 }
@@ -86,7 +95,12 @@ if ( params.help == true || params.input == false || params.ref == false ){
 
 // If none of the above are a problem, then run the workflow
 } else {
-	
+
+// Validate parabricks_version
+if (!['4.6.0', '4.3.2'].contains(params.parabricks_version)) {
+    error "Invalid --parabricks_version '${params.parabricks_version}'. Supported values: '4.6.0' (dgxa100) or '4.3.2' (gpuvolta)."
+}
+
 // CREATE FASTA INDEXES 
 def refFile = file(params.ref)
 def refDir = refFile.parent

--- a/modules/multiqc.nf
+++ b/modules/multiqc.nf
@@ -15,9 +15,11 @@ process multiqc {
     script:
     def args = task.ext.args ?: ''
     """
+    sed 's/parabricks: .*/parabricks: "${params.parabricks_version}"/' ${params.multiqc_config} > multiqc_config_runtime.yml
+
     multiqc . \
         --filename ${params.cohort_name}_multiqc \
-        -c ${params.multiqc_config} \
+        -c multiqc_config_runtime.yml \
         ${args}
     """
 }

--- a/modules/pb_collectmetrics.nf
+++ b/modules/pb_collectmetrics.nf
@@ -15,6 +15,10 @@ process pb_collectmetrics {
     script:
     def args = task.ext.args ?: ''
     """
+    echo "=== Parabricks version check (expected: ${params.parabricks_version}) ==="
+    pbrun version
+    echo "========================================================================="
+
     pbrun bammetrics \\
       --ref ${fasta} \\
       --bam ${bam} \\

--- a/modules/pb_deepvar.nf
+++ b/modules/pb_deepvar.nf
@@ -15,6 +15,10 @@ process pb_deepvariant {
     script:
     def args = task.ext.args ?: ''
     """
+    echo "=== Parabricks version check (expected: ${params.parabricks_version}) ==="
+    pbrun version
+    echo "========================================================================="
+
     pbrun deepvariant \\
       --ref ${fasta} \\
       --in-bam ${bam} \\

--- a/modules/pb_fq2bam.nf
+++ b/modules/pb_fq2bam.nf
@@ -24,6 +24,10 @@ process pb_fq2bam {
         }
         .join(' \\\n')
     """
+        echo "=== Parabricks version check (expected: ${params.parabricks_version}) ==="
+        pbrun version
+        echo "========================================================================="
+
         pbrun fq2bam \\
           --ref ${fasta} \\
           ${in_fq} \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,6 +21,7 @@ params {
     vep_assembly = ''
     download_vep_cache = false
     multiqc_config = "${baseDir}/assets/multiqc_config.yml"
+    parabricks_version = '4.6.0'
 }
 
 // Fail a task if any command returns non-zero exit code

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -65,6 +65,13 @@
                     "description": "Path(s) to NCI storage mounts.",
                     "fa_icon": "fas fa-database",
                     "help_text": "For example: `scratch/ab01` or `scratch/ab01+gdata/ab01+gdata/xy89`"
+                },
+                "parabricks_version": {
+                    "type": "string",
+                    "default": "4.6.0",
+                    "description": "Parabricks version to load. Use '4.6.0' to run on the dgxa100 queue (A100 GPUs) or '4.3.2' to run on the gpuvolta queue (V100 GPUs).",
+                    "fa_icon": "fas fa-microchip",
+                    "enum": ["4.6.0", "4.3.2"]
                 }
             }
         },


### PR DESCRIPTION
This pull request adds support for selecting between two Parabricks versions (4.6.0 and 4.3.2) and automatically configures the pipeline to use the appropriate GPU queue and resources on NCI Gadi. It also improves documentation and logging to make the chosen configuration clear and traceable throughout the workflow.

**Support for multiple Parabricks versions and GPU queues:**

- Added a new `--parabricks_version` parameter (default: 4.6.0) that allows users to select either Parabricks 4.6.0 (A100 GPUs, `dgxa100` queue) or 4.3.2 (V100 GPUs, `gpuvolta` queue). The pipeline automatically adjusts queue, CPU, and memory settings based on the selected version. [[1]](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaR24) [[2]](diffhunk://#diff-4e71455a0179b4aec710684e8f3efd20f7e8ee94fdbfee682ee4e17b4385d312L43-R64) [[3]](diffhunk://#diff-b0628fe7f963371c3f8dd1d5fe052c8d1bd947ce65e6b6f683a178d23c7fcfa4L25-L36) [[4]](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28R99-R103) [[5]](diffhunk://#diff-4ec6c97fca07ea9b1ff300c0c4488d0f097ae32a78f0e0b01e00b9df0c346eb6R68-R74)
- Updated process resource specifications in `config/modules.config` to dynamically set queue, CPU, and memory requirements according to the Parabricks version.

**Documentation updates:**

- Expanded the `README.md` with a new section explaining how to select the Parabricks version and GPU queue, including a resource table and usage example. Also updated tool links to use the latest Parabricks documentation and clarified input file expectations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L146-R178) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R6) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L225-R245)

**Workflow improvements and logging:**

- Added startup log output and per-task logging to clearly indicate the selected Parabricks version, module, and GPU queue. The version is also recorded in the MultiQC report for traceability. [[1]](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28R39-R45) [[2]](diffhunk://#diff-0b3e4da1d754bcd32f48e32eaa8dfcfffd50278513f80cb08938fa855b9a1f35R18-R22) [[3]](diffhunk://#diff-19f458a30f3bcb001d90ef70f115e7d2f0a9fd95caa22a9bcff9a11f9dcf223fR18-R21) [[4]](diffhunk://#diff-814a2999c2939987cb3ea9f31849fa63a22dd33b66f4fcc8f0f20afbc87ea6e4R18-R21) [[5]](diffhunk://#diff-cb3a8e75ad32d71766d3be11ac9143cee22d06604bb99c92f2ba5e646c66985aR27-R30)
- Added parameter validation to ensure only supported Parabricks versions can be specified, with a clear error message if an invalid value is given.

**Schema and help updates:**

- Updated the Nextflow schema and help messages to document the new `--parabricks_version` parameter and its options. [[1]](diffhunk://#diff-4ec6c97fca07ea9b1ff300c0c4488d0f097ae32a78f0e0b01e00b9df0c346eb6R68-R74) [[2]](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28R74-R75)

These changes make the pipeline more flexible and robust for users running on different GPU hardware, and improve clarity and reproducibility of workflow runs.